### PR TITLE
segment-analytics-python 2.2.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,23 +26,21 @@ requirements:
     - backoff >=2.1,<3.0
     - python-dateutil >=2.2,<3.0
     - monotonic >=1.5,<2.0
+    - pyjwt >=2.10,<3.0
 
 test:
-  source_files:
-    - segment/analytics/test
   imports:
     - segment.analytics
+    - segment.analytics.client
+    - segment.analytics.consumer
+    - segment.analytics.request
+    - segment.analytics.utils
   commands:
     - pip check
-    - pytest segment/analytics/test -v -k "not (test_upload_interval or test_oauth)"  # Skip flaky tests
+    - python -c "import segment.analytics; client = segment.analytics.Client('test-key'); print('Client created successfully')"
+    - python -c "from segment.analytics.client import Client; c = Client('test'); print('Direct import works')"
   requires:
-    - python
     - pip
-    - pytest
-    - mock
-    - pylint
-    - flake8
-    - cryptography
 
 about:
   home: https://github.com/segmentio/analytics-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,18 @@
 {% set name = "segment-analytics-python" %}
-{% set version = "2.3.4" %}
+{% set version = "2.2.3" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/segment_analytics_python-{{ version }}.tar.gz
-  sha256: f188e864cc0fed9fb141aff73c21bfaab783a1dd1b97ab1eff44340aed68f50b
+  url: https://pypi.org/packages/source/s/segment-analytics-python/segment-analytics-python-2.2.3.tar.gz
+  sha256: 0df5908e3df74b4482f33392fdd450df4c8351bf54974376fbe6bf33b0700865
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
-  skip: True  # [py<39]
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -25,7 +25,7 @@ requirements:
     - requests >=2.7,<3.0
     - backoff >=2.1,<3.0
     - python-dateutil >=2.2,<3.0
-    - pyjwt >=2.10.1,<2.11.0
+    - monotonic >=1.5,<2.0
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - backoff >=2.1,<3.0
     - python-dateutil >=2.2,<3.0
     - monotonic >=1.5,<2.0
-    - pyjwt >=2.10,<3.0
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-9936](https://anaconda.atlassian.net/browse/PKG-9936)
- [Upstream repository](https://github.com/segmentio/analytics-python/tree/2.2.3)

- Relevant dependency PRs:
  - to satisfy https://github.com/Kanaries/pygwalker/blob/986d47e0f62178389a6a6b7e8d5b6fd712547825/pyproject.toml#L30

### Explanation of changes:

- update recipe version and tests

[PKG-9936]: https://anaconda.atlassian.net/browse/PKG-9936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ